### PR TITLE
Set up GET request during API discussion

### DIFF
--- a/slides/02-deploy.qmd
+++ b/slides/02-deploy.qmd
@@ -247,7 +247,7 @@ jsonlite::fromJSON(metadata)
 
 . . .
 
-This is the same as calling `pin_meta()` on your pins board.
+This gives you the same information as calling `pin_meta()` on your pins board.
 
 ## How do you make a request of your new API?
 

--- a/slides/02-deploy.qmd
+++ b/slides/02-deploy.qmd
@@ -240,10 +240,14 @@ jsonlite::fromJSON(metadata)
 
 ```{python}
 #| eval: false
-board.pin_meta("isabel.zimmerman/test_model").user
+## TODO: add code for GET rquest for a Python model metadata
 ```
 
 :::
+
+. . .
+
+This is the same as calling `pin_meta()` on your pins board.
 
 ## How do you make a request of your new API?
 


### PR DESCRIPTION
Related to #3 

@isabelizimm in this section, we are talking more about APIs and less about pins, so we do really want to show how to make a request for a non-predict endpoint.

Do you think it would be better to use the prototype or pin URL endpoint? I lean toward the metadata one because a) it's a little more substantive than the pin URL and b) we'll talk about the prototype a bit more in detail in another section.